### PR TITLE
Update Dockerfile ports and enable no-cache for podman build

### DIFF
--- a/starexec-containerised/Dockerfile
+++ b/starexec-containerised/Dockerfile
@@ -165,7 +165,7 @@ COPY starexec_podman_key /root/.ssh/starexec_podman_key
 RUN chmod 600 /root/.ssh/starexec_podman_key
 
 # Expose necessary ports
-EXPOSE 443 8080 3306
+EXPOSE 80 443 3306
 
 WORKDIR ${DEPLOY_DIR}
 

--- a/starexec-containerised/Makefile
+++ b/starexec-containerised/Makefile
@@ -25,6 +25,7 @@ starexec:
 	START_TIME=$$(date +%Y-%m-%d\ %H:%M:%S) && echo "Build started at: $$START_TIME" | tee build-$$VERSION.log && \
 	time podman build \
 			-t starexec:$$VERSION . \
+			--no-cache \
 			--ulimit="nofile=100000:100000" 2> >(tee -a build-$$VERSION.log >&2) && \
 	END_TIME=$$(date +%Y-%m-%d\ %H:%M:%S) && echo "Build finished at: $$END_TIME" | tee -a build-$$VERSION.log && \
 	echo "Build duration: $$(date -u -d @$$(( $$(date -d "$$END_TIME" +%s) - $$(date -d "$$START_TIME" +%s) )) +%H:%M:%S)" | tee -a build-$$VERSION.log


### PR DESCRIPTION
Update the exposed ports in the Dockerfile to include HTTP port 80 and enable the no-cache option in the Makefile for podman builds.