### PR TITLE
Upgrade dependencies and enhance cleanup process

### DIFF
--- a/starexec-containerised/Dockerfile
+++ b/starexec-containerised/Dockerfile
@@ -32,7 +32,7 @@ ENV DB_USER se_admin
 ENV DB_PASS dfsdf34RFerfg3TFGRfrF3edFVg12few2
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    TOMCAT_VERSION=7.0.90 \
+    TOMCAT_VERSION=7.0.109 \
     MYSQL_CON_VERSION=8.0.30 \
     DB_NAME=starexec \
     DB_USER=${DB_USER} \
@@ -53,9 +53,17 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Update and install runtime dependencies
 RUN apt-get update --fix-missing && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends --no-install-suggests \
-    apt-utils tzdata sudo git unzip file apache2 tcsh libnuma-dev \
-    openssl dnsutils ca-certificates openjdk-11-jdk curl ant \
-    ant-optional mariadb-client mariadb-server podman locales && \
+    ca-certificates tzdata sudo git unzip file apache2 tcsh libnuma-dev \
+    openssl dnsutils curl ant ant-optional mariadb-client mariadb-server podman locales && \
+    # Download and install Temurin JDK 16 directly
+    curl -fsSL -o /tmp/jdk16.tar.gz https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz && \
+    mkdir -p /usr/lib/jvm && \
+    tar xzf /tmp/jdk16.tar.gz -C /usr/lib/jvm && \
+    rm /tmp/jdk16.tar.gz && \
+    # Set Java alternatives
+    update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk-16.0.2+7/bin/java 1 && \
+    update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/jdk-16.0.2+7/bin/javac 1 && \
+    # Cleanup and final steps
     a2enmod ssl && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -76,8 +84,9 @@ RUN printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAl
     rm /tmp/openssl.cnf
 
 # Install Node.js and Sass
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs --no-install-recommends --no-install-suggests && \
+    npm install -g npm@latest && \
     npm install -g sass
 
 # Configure Apache2

--- a/starexec-containerised/Makefile
+++ b/starexec-containerised/Makefile
@@ -40,7 +40,7 @@ run:
 			-e HOST_MACHINE=localhost \
 			-e SSH_PORT=22 \
 			-e SSH_SOCKET_PATH=${PODMAN_SOCKET_PATH} \
-			-p 80:80 -p 443:443 starexec
+			-p 80:80 -p 443:443 starexec:${VERSION}
 
 	# ${SSH_USERNAME}@${HOST_MACHINE}:${SSH_PORT}${SOCKET_PATH}
 clean:

--- a/starexec-containerised/init-starexec.sh
+++ b/starexec-containerised/init-starexec.sh
@@ -10,15 +10,21 @@ function error() {
 
 function cleanup() {
   echo "Container stopped, performing cleanup..."
+  
+  # Attempt a graceful shutdown of Tomcat
   /project/apache-tomcat-7/bin/shutdown.sh || true
-
+  
   # Wait briefly for Tomcat to finish cleaning up
   sleep 5
-
+  
+  # Forcibly kill any remaining Tomcat processes (matching the Bootstrap class)
+  pkill -f 'org.apache.catalina.startup.Bootstrap' || true
+  
   /usr/bin/mysqladmin -u root shutdown || true
   /usr/sbin/apache2ctl -k graceful-stop || true
   exit 0
 }
+
 
 # Trap signals for cleanup
 trap cleanup SIGINT SIGTERM


### PR DESCRIPTION
Upgrade container runtime dependencies, including Tomcat and Node.js, while enhancing the cleanup function to gracefully shut down Tomcat and handle remaining processes. Update the Makefile to specify the image version for the StarExec container.