### PR TITLE
Update .gitignore for key and certificate patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,11 @@ starexec-proxy-provers/__pycache__
 *~
 venv/
 # SSH keys for Podman
-starexec_podman_key
-starexec_podman_key.pub
+**/*key
+**/*.pub
+
+# Certificates
+**/*.crt
 
 # Build logs
 build-*.log


### PR DESCRIPTION
Enhance the .gitignore file to include additional patterns for SSH keys and certificates, improving security by preventing sensitive files from being tracked.