### PR TITLE
Refactor Makefile for prover builds and update README

### DIFF
--- a/provers-containerised/Makefile
+++ b/provers-containerised/Makefile
@@ -1,59 +1,63 @@
 #------------------------------------------------------------
-.PHONY: base ubuntu-arc tptp-world provers eprover iprover leo3 vampire
+# Variables
+PROVERS           = eprover vampire leo3
+EPROVER_VERSION   = 3.0.03
+VAMPIRE_VERSION   = 4.8
+LEO3_VERSION       = 1.7.0
 
-#----Current versions of each prover as variables:
-EPROVER_VERSION = 3.0.03
-VAMPIRE_VERSION = 4.8
-LEO3_VERSION = 1.7.0
+# Raw sub‐dirs under ./provers
+E_RAW_DIR         = E---$(EPROVER_VERSION)
+V_RAW_DIR         = Vampire---$(VAMPIRE_VERSION)
+L_RAW_DIR         = Leo-III---$(LEO3_VERSION)
 
 #------------------------------------------------------------
-#----High level targets 
-all: base provers
-	echo "Now try 'run_image.py eprover:$(EPROVER_VERSION)-RLR -P PUZ001+1.p'"
+# Functions to pick version or raw‑dir by prover name
+define version_of
+	$(if $(filter $1,eprover),$(EPROVER_VERSION),  \
+	$(if $(filter $1,vampire),$(VAMPIRE_VERSION),  \
+	$(if $(filter $1,leo3),$(LEO3_VERSION))))
+endef
 
+define raw_dir
+	$(if $(filter $1,eprover),$(E_RAW_DIR),         \
+	$(if $(filter $1,vampire),$(V_RAW_DIR),         \
+	$(if $(filter $1,leo3),$(L_RAW_DIR))))
+endef
+
+#------------------------------------------------------------
+# Phony targets
+.PHONY: all base ubuntu-arc tptp-world provers           \
+				$(PROVERS)                                       \
+				$(addsuffix -RAW,$(PROVERS))                     \
+				$(addsuffix -RLR,$(PROVERS))
+
+# Default
+all: base provers
+	@echo "Now try 'run_image.py eprover:$(EPROVER_VERSION)-RLR -P PUZ001+1.p'"
+
+# Build base images
 base: ubuntu-arc tptp-world
 
-provers: eprover leo3 vampire
-
-#------------------------------------------------------------
-#----Prerequisite targets 
 ubuntu-arc:
 	podman build -t ubuntu-arc ./ubuntu-arc
 
 tptp-world: ubuntu-arc
 	podman build -t tptp-world ./tptp-world
 
-scala-build:
-	podman build -t scala-build ./base-build/scala-build
-
 #------------------------------------------------------------
-#----Targets for each prover 
+# Generate each prover’s RAW, RLR and shortcut targets
+provers: $(PROVERS)
 
-#---Eprover targets 
-eprover: eprover-RLR
+$(PROVERS): %: %-RLR
 
-eprover-RLR: eprover-RAW tptp-world
-	podman build -t eprover:$(EPROVER_VERSION)-RLR --build-arg PROVER_IMAGE=eprover:$(EPROVER_VERSION) ./provers
+%-RAW: ubuntu-arc
+	podman build \
+		-t $@:$(call version_of,$@) \
+		./provers/$(call raw_dir,$@)
 
-eprover-RAW: ubuntu-arc
-	podman build -t eprover:$(EPROVER_VERSION) ./provers/E---$(EPROVER_VERSION)
+%-RLR: %-RAW tptp-world
+	podman build \
+		-t $@:$(call version_of,$*)-RLR \
+		--build-arg PROVER_IMAGE=$*:$(call version_of,$*) \
+		./provers
 
-#----Vampire targets
-vampire: vampire-RLR
-
-vampire-RLR: vampire-RAW tptp-world
-	podman build -t vampire:$(VAMPIRE_VERSION)-RLR --build-arg PROVER_IMAGE=vampire:$(VAMPIRE_VERSION) ./provers
-
-vampire-RAW: ubuntu-arc
-	podman build -t vampire:$(VAMPIRE_VERSION) ./provers/Vampire---$(VAMPIRE_VERSION)
-
-#----Leo3 targets
-leo3: leo3-RLR
-
-leo3-RLR: leo3-RAW tptp-world
-	podman build -t leo3:$(LEO3_VERSION)-RLR --build-arg PROVER_IMAGE=leo3:$(LEO3_VERSION) ./provers
-
-leo3-RAW: 
-	podman build -t leo3:$(LEO3_VERSION) ./provers/Leo-III---$(LEO3_VERSION)
-
-#------------------------------------------------------------

--- a/provers-containerised/README.md
+++ b/provers-containerised/README.md
@@ -11,13 +11,13 @@ This folder contains all the necessary components to containerize an Automated T
   - Contains a `Dockerfile` to build a container with various TPTP World software required by provers and necessary for running them.
 
 - **`provers`**
-  - Contains individual prover folders, each with sources and related files.
+  - Contains individual prover folders, each with sources and related files. The directory name follows the pattern `Prover---Version` (e.g., `E---3.0.03`).
   - Includes the `start_RLR` script used to execute a prover under the control of a Resource Limited Run program (currently `runsolver`) with appropriate logging for the TPTP World.
   - Contains a `Dockerfile` for building containers for each specified prover (refer to the comments in the `Dockerfile`).
     - Each prover's folder includes a `Dockerfile` for building the prover in a container.
     - **Tag Naming Convention:**
       - **Prover Containers:** `prover:version`
-        - *Prover* must be lowercase (due to docker/podman requirements).
+        - *Prover* must be lowercase (due to docker/podman requirements). The prover name and version are typically defined in the `Makefile`.
         - The tag name is provided as the `--build-arg PROVER_IMAGE` value when building the resource limited prover container.
       - **Resource Limited Prover Containers:** `prover:version-RLR`
 
@@ -26,12 +26,19 @@ This folder contains all the necessary components to containerize an Automated T
   - Run `run_image.py -h` for detailed usage instructions.
 
 - **`Makefile`**
-  - Builds `ubuntu-arc`, `tptp-world`, and selected resource-limited prover containers.
-  - Refer to the `Makefile` to see the currently supported provers.
+  - Builds `ubuntu-arc`, `tptp-world`, and selected resource-limited prover containers (defined by the `PROVERS` variable).
+  - Defines prover versions (e.g., `EPROVER_VERSION`) and directory names (e.g., `E_RAW_DIR`).
+  - Provides targets for building base images (`make base`), individual prover images (`make eprover-RAW`), and resource-limited prover images (`make eprover` or `make eprover-RLR`). Run `make` or `make all` to build everything defined in `PROVERS`.
+  - Refer to the `Makefile` to see the currently supported provers and their versions.
 
-## Building and Running a TPTP Docker Image (Example: E 3.0.03)
+## Building and Running a TPTP Docker Image (Example: E prover using Makefile variables)
+
+> *Note: The `Makefile` automates these steps. You can run `make eprover` to build the E prover RLR image directly, or `make all` to build all defined provers.*
+> *The example below shows the manual steps, using placeholders like `<EPROVER_VERSION>` which correspond to variables defined in the `Makefile` (e.g., `EPROVER_VERSION=3.0.03`).*
 
 1. **Clone the Repository and Build the `ubuntu-arc` Image:**
+    > *(Or run `make ubuntu-arc`)*
+
     ```shell
     git clone https://github.com/StarExecMiami/starexec-arc
     cd starexec-arc/provers-containerised/ubuntu-arc
@@ -39,40 +46,53 @@ This folder contains all the necessary components to containerize an Automated T
     ```
 
 2. **Build the `tptp-world` Image:**
+    > *(Or run `make tptp-world`)*
+
     ```shell
     cd ../tptp-world
     podman build --no-cache -t tptp-world .
     ```
 
 3. **Build the `eprover` Image:**
-    > *Note: The prover name is lowercase (`eprover`) to comply with docker/podman naming conventions.*
+    > *Note: The prover name is lowercase (`eprover`) to comply with docker/podman naming conventions. The directory name and version tag should match the `Makefile` definitions (e.g., `E---<EPROVER_VERSION>` and `eprover:<EPROVER_VERSION>`).*
+    > *(Or run `make eprover-RAW`)*
+
     ```shell
-    cd ../provers/E---3.0.03
-    podman build --no-cache -t eprover:3.0.03 .
+    # Replace <EPROVER_VERSION> with the actual version from the Makefile (e.g., 3.0.03)
+    cd ../provers/E---<EPROVER_VERSION> 
+    podman build --no-cache -t eprover:<EPROVER_VERSION> .
     ```
 
-4. **Build the `eprover:3.0.03-RLR` Resource Limited Prover Container:**
+4. **Build the `eprover:<EPROVER_VERSION>-RLR` Resource Limited Prover Container:**
+    > *(Or run `make eprover-RLR` or simply `make eprover`)*
+
     ```shell
-    cd ..
-    podman build -t eprover:3.0.03-RLR --build-arg PROVER_IMAGE=eprover:3.0.03 .
+    cd .. 
+    # Replace <EPROVER_VERSION> with the actual version from the Makefile (e.g., 3.0.03)
+    podman build -t eprover:<EPROVER_VERSION>-RLR --build-arg PROVER_IMAGE=eprover:<EPROVER_VERSION> .
     ```
 
-5. **Test Using the `run_image.py` Scrip on PUZ001+1 (provided)t:**
+5. **Test Using the `run_image.py` Script on PUZ001+1 (provided):**
+
     ```shell
     cd ..
-    run_image.py eprover:3.0.03-RLR -P PUZ001+1.p -W 60 -I THM
+    # Replace <EPROVER_VERSION> with the actual version from the Makefile (e.g., 3.0.03)
+    ./run_image.py eprover:<EPROVER_VERSION>-RLR -P PUZ001+1.p -W 60 -I THM
     ```
 
 6. **Push to Docker Hub:**
+
     ```shell
     podman login docker.io 
     # (Provide credentials as prompted)
-    podman tag eprover:3.0.03-RLR docker.io/tptpstarexec/eprover:3.0.03-RLR-your_architecture (e.g., arm64, amd64)
-    podman push docker.io/tptpstarexec/eprover:3.0.03-RLR-your_architecture
+    # Replace <EPROVER_VERSION> with the actual version from the Makefile (e.g., 3.0.03)
+    podman tag eprover:<EPROVER_VERSION>-RLR docker.io/tptpstarexec/eprover:<EPROVER_VERSION>-RLR-your_architecture (e.g., arm64, amd64)
+    podman push docker.io/tptpstarexec/eprover:<EPROVER_VERSION>-RLR-your_architecture
     ```
 
     - **Pulling from Docker Hub:**
+  
       ```shell
-      podman pull tptpstarexec/eprover:3.0.03-RLR-your_architecture
+      # Replace <EPROVER_VERSION> with the actual version (e.g., 3.0.03)
+      podman pull tptpstarexec/eprover:<EPROVER_VERSION>-RLR-your_architecture
       ```
-


### PR DESCRIPTION
Streamline prover build targets by introducing variables for versions and directories, reducing duplication. Update README to clarify usage of Makefile variables and enhance instructions for building prover images.