### PR TITLE
Improve clarity of build instructions in README

### DIFF
--- a/provers-containerised/README.md
+++ b/provers-containerised/README.md
@@ -38,49 +38,50 @@ This folder contains all the necessary components to containerize an Automated T
     by the `PROVERS` variable).
   - Defines prover versions (e.g., `EPROVER_VERSION`) and directory names (e.g., `E_RAW_DIR`).
   - Provides targets for building base images (`make base`), individual prover images
-    (e.g., `make eprover-RAW`), and resource-limited prover images (e.g., `make eprover` or 
+    (e.g., `make eprover-RAW`), and resource-limited prover images (e.g., `make eprover` or
     `make eprover-RLR`). Run `make` or `make all` to build everything defined in `PROVERS`.
   - Refer to the `Makefile` to see the currently supported provers and their versions.
 
 ## Building and running a containerised prover
 
 Note: The `Makefile` automates these steps.
-You can run `make eprover` to build the E prover RLR image directly, or `make all` to build all
+You can run `make eprover` (which is a shortcut for `make eprover-RLR`) to build the E prover RLR image directly, or `make all` to build all
 defined provers.
-The example below shows the manual steps.
+The example below shows the manual steps, using `eprover` with version `EPROVER_VERSION` (as defined in the `Makefile`) as an example.
+Refer to the `Makefile` for the actual `EPROVER_VERSION` and for other provers.
 
 1. Clone the repository and build the `ubuntu-arc` image:  
     `git clone https://github.com/StarExecMiami/starexec-arc`  
     `cd starexec-arc/provers-containerised/ubuntu-arc`  
     `podman build --no-cache -t ubuntu-arc .`
-    > *(Or run `make ubuntu-arc`)*
+    > *(Or run `make ubuntu-arc` from the `provers-containerised` directory)*
 
 2. Build the `tptp-world` image:  
     `cd ../tptp-world`  
     `podman build --no-cache -t tptp-world .`  
-    > *(Or run `make tptp-world`)*
+    > *(Or run `make tptp-world` from the `provers-containerised` directory)*
 
-3. Build the `prover` image:  
+3. Build the `prover` image (equivalent to `make eprover-RAW`):  
    *Note: The prover name is lowercase (e.g., `eprover`) to comply with docker/podman naming
-   conventions.*  
-    `cd ../provers/Prover---Version`  
-    `podman build --no-cache -t prover:version .`  
-    > (Or run `make prover-RAW`)
+   conventions. The version is taken from the `Makefile` (e.g., `EPROVER_VERSION`).
+   The directory name is also derived from the `Makefile` (e.g., `E---<EPROVER_VERSION>`).*  
+    `cd ../provers/E---<EPROVER_VERSION>`  with the actual version
+    `podman build --no-cache -t eprover:<EPROVER_VERSION> .`
+    > (Or run `make eprover-RAW` from the `provers-containerised` directory. The `Makefile` will use the correct version and directory for `eprover`.)
 
-4. Build the `prover:version-RLR` resource limited prover container:  
-    `cd ..`  
-    `podman build -t prover:version-RLR --build-arg PROVER_IMAGE=prover:version .`  
-    > (Or run `make prover-RLR` or simply `make eprover`)
+4. Build the `prover:version-RLR` resource limited prover container (equivalent to `make eprover-RLR` or `make eprover`):  
+    `cd ..` (should be in the `provers-containerised/provers` directory)
+    `podman build -t eprover:<EPROVER_VERSION>-RLR --build-arg PROVER_IMAGE=eprover:<EPROVER_VERSION> .`
+    > (Or run `make eprover-RLR` or simply `make eprover` from the `provers-containerised` directory.)
 
 5. Test using the `run_image.py` script on PUZ001+1 (provided):  
-    `cd ..`  
-    `./run_image.py eprover:<EPROVER_VERSION>-RLR -P PUZ001+1.p -W 60 -I THM`  
+    `cd ..` (should be in the `provers-containerised` directory)
+    `./run_image.py eprover:<EPROVER_VERSION>-RLR -P PUZ001+1.p -W 60 -I THM`
 
 6. Push to DockerHub:  
     `podman login docker.io`  
-    `podman tag prover:version-RLR docker.io/tptpstarexec/prover:version-RLR-your_architecture`  
-     (e.g., arm64, amd64)  
-    `podman push docker.io/tptpstarexec/eprover:<EPROVER_VERSION>-RLR-your_architecture`  
+    `podman tag eprover:<EPROVER_VERSION>-RLR docker.io/tptpstarexec/eprover:<EPROVER_VERSION>-RLR-your_architecture` (e.g., arm64, amd64)  
+    `podman push docker.io/tptpstarexec/eprover:<EPROVER_VERSION>-RLR-your_architecture`
 
     - Pulling from DockerHub:  
-      `podman pull tptpstarexec/prover:version-RLR-your_architecture`
+      `podman pull tptpstarexec/eprover:<EPROVER_VERSION>-RLR-your_architecture`


### PR DESCRIPTION
Enhance the README documentation by clarifying build commands, improving formatting, and providing consistent examples for building prover images. Include specific version placeholders and directory navigation details to aid users in the build process.